### PR TITLE
fix: re-export types from vdom [CEC-361]

### DIFF
--- a/packages/generative-experiences-js/src/index.ts
+++ b/packages/generative-experiences-js/src/index.ts
@@ -1,3 +1,4 @@
+export type * from '@algolia/generative-experiences-vdom';
 export * from './shoppingGuidesContent';
 export * from './shoppingGuidesFeedback';
 export * from './shoppingGuidesHeadlines';

--- a/packages/generative-experiences-react/src/index.ts
+++ b/packages/generative-experiences-react/src/index.ts
@@ -1,3 +1,4 @@
+export type * from '@algolia/generative-experiences-vdom';
 export * from './ShoppingGuidesHeadlines';
 export * from './ShoppingGuidesContent';
 export * from './ShoppingGuidesFeedback';


### PR DESCRIPTION
When trying the React package I noticed that I was missing some types: `ContentViewProps`, `GSEHeadlineRecord` & `ContentItemComponentProps`


I don't think there is any harm in re-exporting all the types though 🤔 