### PR TITLE
fix: fix Shopping/Comparison guide content type

### DIFF
--- a/packages/generative-experiences-api-client/src/types/shopping-guide.ts
+++ b/packages/generative-experiences-api-client/src/types/shopping-guide.ts
@@ -16,7 +16,7 @@ export type CategoryGuide = BaseShoppingGuide & {
   content: Array<{
     type: 'conclusion' | 'factor' | 'introduction';
     title: string;
-    content: string[];
+    content: string;
   }>;
   score_headline: number;
 };
@@ -26,7 +26,7 @@ export type ShoppingGuideType = BaseShoppingGuide & {
   description: string;
   category: string;
   objects: Hit[];
-  content: Array<{ title: string; content: string[] }>;
+  content: Array<{ title: string; content: string }>;
   score_headline: number;
 };
 
@@ -37,7 +37,7 @@ export type ComparisonGuide = BaseShoppingGuide & {
     title: string;
     type: 'conclusion' | 'introduction' | 'product';
     objectID?: string;
-    content: string[];
+    content: string;
   }>;
   comparedObjectIDs: string[];
 };

--- a/packages/generative-experiences-js/src/hooks/useShoppingGuidesContent.ts
+++ b/packages/generative-experiences-js/src/hooks/useShoppingGuidesContent.ts
@@ -20,7 +20,7 @@ const defaultState: ShoppingGuideType = {
   content: [
     {
       title: '',
-      content: [],
+      content: '',
     },
   ],
   score_headline: 0,

--- a/packages/generative-experiences-react/src/useShoppingGuidesContent.ts
+++ b/packages/generative-experiences-react/src/useShoppingGuidesContent.ts
@@ -20,7 +20,7 @@ const defaultState: ShoppingGuideType = {
   content: [
     {
       title: '',
-      content: [],
+      content: '',
     },
   ],
   score_headline: 0,

--- a/packages/generative-experiences-vdom/src/types/ShoppingGuideContentProps.ts
+++ b/packages/generative-experiences-vdom/src/types/ShoppingGuideContentProps.ts
@@ -17,7 +17,7 @@ export const defaultState: ShoppingGuideType = {
   content: [
     {
       title: '',
-      content: [],
+      content: '',
     },
   ],
   score_headline: 0,
@@ -52,7 +52,7 @@ export type GSEContentRecord = {
       content: Array<{
         type: 'conclusion' | 'factor' | 'introduction';
         title: string;
-        content: string[];
+        content: string;
       }>;
       score_headline: number;
     }
@@ -63,7 +63,7 @@ export type GSEContentRecord = {
         title: string;
         type: 'conclusion' | 'introduction' | 'product';
         objectID?: string;
-        content: string[];
+        content: string;
       }>;
       comparedObjectIDs: string[];
     }
@@ -72,7 +72,7 @@ export type GSEContentRecord = {
       description: string;
       category: string;
       objects: Hit[];
-      content: Array<{ title: string; content: string[] }>;
+      content: Array<{ title: string; content: string }>;
       score_headline: number;
     }
 );


### PR DESCRIPTION
As reported by @brandonbews 

* `ShoppingGuideType`, `CategoryGuide` & `ComparisonGuide`: 

```
 content: Array<{
    title: string
    content: string // Type in response is a string, not an array of strings
  }>
```