### PR TITLE
fix: make category optional when fetching headlines [cec-594]

### DIFF
--- a/packages/generative-experiences-api-client/README.md
+++ b/packages/generative-experiences-api-client/README.md
@@ -84,16 +84,16 @@ client
   .then((response) => console.log(response));
 ```
 
-| Prop name        | Type                                        | Default | Description                                                                               | Notes |
-|------------------|---------------------------------------------| --- |-------------------------------------------------------------------------------------------| --- |
-| `category`       | `string`                                    | N/A | The category to use for retrieving/generating the headlines.                              | `required` |
-| `nbHeadlines`    | `number \| undefined`                       | 4 | The number of headlines to display.                                                       | - |
-| `source`         | `'combined' \| 'generated' \| 'index'`      | `index` | The source of the headlines.                                                              | - |
-| `tone`           | `'natural' \| 'friendly' \| 'professional'` | `natural` | The model will use a specific tone when provided.                                         | - |
-| `language_code`  | `'english' \| 'german' \| 'french'`         | `english` | The language code used for generating headlines.                                          | - |
-| `custom_content` | `string`                                    | - | The extended instrcutions that the model should take into account for generating content. | - |
-| `keywords`       | `string[]`                                  | - | A list of keywords that the model should highlight in the generated content.              | - |
-| `onlyPublished`  | `boolean`                                   | `true` | Only display published guides.                                                            | - |
+| Prop name | Type | Default | Description | Notes |
+| --- | --- | --- | --- | --- |
+| `category` | `string \| undefined` | N/A | The category to use for retrieving/generating the headlines. | - |
+| `nbHeadlines` | `number \| undefined` | 4 | The number of headlines to display. | - |
+| `source` | `'combined' \| 'generated' \| 'index'` | `index` | The source of the headlines. | - |
+| `tone` | `'natural' \| 'friendly' \| 'professional'` | `natural` | The model will use a specific tone when provided. | - |
+| `language_code` | `'english' \| 'german' \| 'french'` | `english` | The language code used for generating headlines. | - |
+| `custom_content` | `string` | - | The extended instrcutions that the model should take into account for generating content. | - |
+| `keywords` | `string[]` | - | A list of keywords that the model should highlight in the generated content. | - |
+| `onlyPublished` | `boolean` | `true` | Only display published guides. | - |
 
 ### Guides Content
 
@@ -144,8 +144,8 @@ client
 | `type` | `'shopping_guide' \| 'category_guide'` | `shopping_guide` | The type of guide to generate. | Used if `source` is `generated` |
 | `tone` | `'natural' \| 'friendly' \| 'professional'` | `natural` | The model will use a specific tone when provided. | - |
 | `language_code` | `'english' \| 'german' \| 'french'` | `english` | The language code used for generating content. | - |
-| `custom_content` | `string`                                    | - | The extended instrcutions that the model should take into account for generating content. | - |
-| `keywords`       | `string[]`                                  | - | A list of keywords that the model should highlight in the generated content.              | - |
+| `custom_content` | `string` | - | The extended instrcutions that the model should take into account for generating content. | - |
+| `keywords` | `string[]` | - | A list of keywords that the model should highlight in the generated content. | - |
 | `onlyPublished` | `boolean` | `true` | Only display published guides. | - |
 
 ### Gather Feedback

--- a/packages/generative-experiences-api-client/README.md
+++ b/packages/generative-experiences-api-client/README.md
@@ -87,7 +87,7 @@ client
 | Prop name | Type | Default | Description | Notes |
 | --- | --- | --- | --- | --- |
 | `category` | `string \| undefined` | N/A | The category to use for retrieving/generating the headlines. | - |
-| `nbHeadlines` | `number \| undefined` | 4 | The number of headlines to display. | - |
+| `maxHeadlines` | `number \| undefined` | 4 | The maximum number of headlines to display. | Maximum 1,000 |
 | `source` | `'combined' \| 'generated' \| 'index'` | `index` | The source of the headlines. | - |
 | `tone` | `'natural' \| 'friendly' \| 'professional'` | `natural` | The model will use a specific tone when provided. | - |
 | `language_code` | `'english' \| 'german' \| 'french'` | `english` | The language code used for generating headlines. | - |

--- a/packages/generative-experiences-api-client/src/client.ts
+++ b/packages/generative-experiences-api-client/src/client.ts
@@ -398,7 +398,6 @@ export function createClient(opts: CreateClientOptions) {
             requestParams
           );
         }
-        // @ts-expect-error - types for params clash
         return await this.generateHeadlines(params, requestParams);
       }
 

--- a/packages/generative-experiences-api-client/src/helpers/records.ts
+++ b/packages/generative-experiences-api-client/src/helpers/records.ts
@@ -14,7 +14,7 @@ export const getObjects = async (
     })),
   });
 
-  return response.results;
+  return response?.results ?? [];
 };
 
 export const getObjectIDs = (objects: Hit[]): Array<Hit['objectID']> =>

--- a/packages/generative-experiences-api-client/src/types/guides-headlines.ts
+++ b/packages/generative-experiences-api-client/src/types/guides-headlines.ts
@@ -58,14 +58,14 @@ export type GuideHeadlinesOptionsForIndex = {
 export type GuideHeadlinesOptionsForGenerated = Partial<GuideHeadlinesRequestParameters> & {
   source: 'generated';
   nbHeadlines?: number;
-  category: string;
+  category?: string;
   showFeedback?: boolean;
 };
 
 export type GuideHeadlinesOptionsForCombined = {
   source: 'combined';
   nbHeadlines?: number;
-  category: string;
+  category?: string;
   showFeedback?: boolean;
   object?: { objectID: string };
   breadcrumbs?: string[];

--- a/packages/generative-experiences-api-client/src/types/guides-headlines.ts
+++ b/packages/generative-experiences-api-client/src/types/guides-headlines.ts
@@ -41,7 +41,7 @@ export type GuideHeadlinesRequestParameters = {
 
 export type GuideHeadlinesOptionsForIndex = {
   source?: 'index';
-  nbHeadlines?: number;
+  maxHeadlines?: number;
   showFeedback?: boolean;
   category?: string;
   object?: { objectID: string };
@@ -57,14 +57,14 @@ export type GuideHeadlinesOptionsForIndex = {
 };
 export type GuideHeadlinesOptionsForGenerated = Partial<GuideHeadlinesRequestParameters> & {
   source: 'generated';
-  nbHeadlines?: number;
+  maxHeadlines?: number;
   category?: string;
   showFeedback?: boolean;
 };
 
 export type GuideHeadlinesOptionsForCombined = {
   source: 'combined';
-  nbHeadlines?: number;
+  maxHeadlines?: number;
   category?: string;
   showFeedback?: boolean;
   object?: { objectID: string };

--- a/packages/generative-experiences-js/README.md
+++ b/packages/generative-experiences-js/README.md
@@ -99,7 +99,7 @@ guidesHeadlines({
 | --- | --- | --- | --- | --- |
 | `client` | - | N/A | The Algolia Generative Experiences client. | `required` |
 | `category` | `string \| undefined` | N/A | The category to use for retrieving/generating the headlines. | - |
-| `nbHeadlines` | `number \| undefined` | 4 | The number of headlines to display. | - |
+| `maxHeadlines` | `number \| undefined` | 4 | The maximum number of headlines to display. | Maximum 1,000 |
 | `onlyPublished` | `boolean` | `true` | Only return headlines that have had their content generated. | - |
 | `showImmediate` | `boolean` | `false` | Whether to generate/display the headlines on load. | - |
 | `showFeedback` | `boolean` | `false` | Whether to show the feedback buttons. | - |

--- a/packages/generative-experiences-js/README.md
+++ b/packages/generative-experiences-js/README.md
@@ -98,7 +98,7 @@ guidesHeadlines({
 | Prop name | Type | Default | Description | Notes |
 | --- | --- | --- | --- | --- |
 | `client` | - | N/A | The Algolia Generative Experiences client. | `required` |
-| `category` | `string` | N/A | The category to use for retrieving/generating the headlines. | `required` |
+| `category` | `string \| undefined` | N/A | The category to use for retrieving/generating the headlines. | - |
 | `nbHeadlines` | `number \| undefined` | 4 | The number of headlines to display. | - |
 | `onlyPublished` | `boolean` | `true` | Only return headlines that have had their content generated. | - |
 | `showImmediate` | `boolean` | `false` | Whether to generate/display the headlines on load. | - |
@@ -145,8 +145,8 @@ shoppingGuideContent({
 | `client` | - | N/A | The Algolia Generative Experiences client. | `required` |
 | `objectID` | `string` | N/A | The objectID for the guide to be retrieved/generated. | `required` |
 | `itemComponent` | `ReactNode` | N/A | Component to display items (from an algolia index) listed throughout the guide. | `required` |
-| `featuredItemsTitle` | `string` | Items featured in this article | The title of the realted items carousel found at the end of a guide.            | - |
-| `maxFeaturedItems` | `number`            | 4 | The number of featured items displayed at the end of a guide.                   | - |
+| `featuredItemsTitle` | `string` | Items featured in this article | The title of the realted items carousel found at the end of a guide. | - |
+| `maxFeaturedItems` | `number` | 4 | The number of featured items displayed at the end of a guide. | - |
 | `onlyPublished` | `boolean` | `true` | Only display published guides. | - |
 | `showImmediate` | `boolean` | `true` | Whether to generate/display the content on load. | - |
 | `showFeedback` | `boolean` | `false` | Whether to show the feedback buttons. | - |
@@ -248,131 +248,131 @@ To integrate the widgets with Tailwind, include the `@tailwindcss/typography` pl
 
 ```css
 .ais-NoWrap {
-    @apply whitespace-nowrap;
+  @apply whitespace-nowrap;
 }
 
 .ais-ScreenReaderOnly {
-    @apply sr-only;
+  @apply sr-only;
 }
 
 /* display headlines */
 .ais-GuideHeadlinesContent-wrapper {
-    @apply rounded p-4 border border-gray-100 shadow gap-2;
+  @apply rounded p-4 border border-gray-100 shadow gap-2;
 }
 
 .ais-GuideHeadlinesContent-container {
-    @apply flex flex-col items-end;
+  @apply flex flex-col items-end;
 }
 
 .ais-GuideHeadlinesContent-itemsContainer {
-    @apply flex items-center gap-6;
+  @apply flex items-center gap-6;
 }
 
 .ais-GuideHeadlinesContent-readMore {
-    @apply flex text-white py-2 mt-8 border-2 bg-blue-700 rounded-md items-center w-full justify-center;
+  @apply flex text-white py-2 mt-8 border-2 bg-blue-700 rounded-md items-center w-full justify-center;
 }
 
 .ais-GuideHeadlinesContent-item {
-    @apply bg-neutral-100 rounded p-4 space-y-3 flex justify-between min-h-[420px];
+  @apply bg-neutral-100 rounded p-4 space-y-3 flex justify-between min-h-[420px];
 }
 
 .ais-GuideHeadlinesContent-itemContent {
-    @apply mt-5;
+  @apply mt-5;
 }
 
 .ais-GuideHeadlinesContent-itemTitle {
-    @apply text-blue-800 font-semibold line-clamp-2 h-12;
+  @apply text-blue-800 font-semibold line-clamp-2 h-12;
 }
 
 .ais-GuideHeadlinesContent-itemDescription {
-    @apply line-clamp-4 text-base mt-2;
+  @apply line-clamp-4 text-base mt-2;
 }
 
 .ais-GuideHeadlinesContent-itemImage {
-    @apply relative min-h-[120px] max-h-[120px] w-auto overflow-hidden mx-auto mt-4 aspect-square;
+  @apply relative min-h-[120px] max-h-[120px] w-auto overflow-hidden mx-auto mt-4 aspect-square;
 }
 
 /* display content */
 .ais-GuideContent-contentSection {
-    @apply prose max-w-prose mx-auto px-4;
+  @apply prose max-w-prose mx-auto px-4;
 }
 
 .ais-GuideContent {
-    @apply mb-10 w-full;
+  @apply mb-10 w-full;
 }
 
 .ais-GuideContent-heroImage {
-    @apply mx-auto min-h-[200px] max-h-[250px] my-12;
+  @apply mx-auto min-h-[200px] max-h-[250px] my-12;
 }
 
 .ais-GuideContent .ais-Feedback {
-    @apply flex items-end justify-end mx-auto;
+  @apply flex items-end justify-end mx-auto;
 }
 
 .ais-GuideContent-factorsList {
-    @apply flex flex-wrap list-disc gap-x-2 justify-between w-full;
+  @apply flex flex-wrap list-disc gap-x-2 justify-between w-full;
 }
 
 .ais-GuideContent-factorItem {
-    @apply w-[45%];
+  @apply w-[45%];
 }
 
 .ais-GuideContent-relatedItemsSection {
-    @apply prose max-w-none mx-auto px-4;
+  @apply prose max-w-none mx-auto px-4;
 }
 
 .ais-GuideContent-relatedItemsTitle {
-    @apply max-w-prose mx-auto px-4;
+  @apply max-w-prose mx-auto px-4;
 }
 
 .ais-GuideContent-relatedItemsListContainer {
-    @apply max-w-prose mx-auto px-4;
+  @apply max-w-prose mx-auto px-4;
 }
 
 .ais-GuideContent-relatedItemsList {
-    @apply p-2 flex justify-between flex-wrap list-none;
+  @apply p-2 flex justify-between flex-wrap list-none;
 }
 
 /* display feedback */
 .ais-Feedback {
-    @apply text-gray-500 text-base max-w-prose mt-10;
+  @apply text-gray-500 text-base max-w-prose mt-10;
 }
 
 .ais-feedbackContainer {
-    @apply flex items-center gap-4;
+  @apply flex items-center gap-4;
 }
 
 .ais-Feedback-thanksWrapper {
-    @apply flex items-center;
+  @apply flex items-center;
 }
 
 .ais-Feedback-labelWrapper {
-    @apply flex space-x-2 items-center;
+  @apply flex space-x-2 items-center;
 }
 
 .ais-Feedback-labelIcon {
-    @apply h-6 w-6 flex-shrink-0;
+  @apply h-6 w-6 flex-shrink-0;
 }
 
 .ais-Feedback-button {
-    @apply inline-block rounded font-semibold text-center shadow-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 bg-white hover:bg-white border-2 border-gray-400 hover:border-gray-500 focus-visible:outline-gray-500 text-gray-400 hover:text-gray-500 px-2.5 py-1.5;
+  @apply inline-block rounded font-semibold text-center shadow-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 bg-white hover:bg-white border-2 border-gray-400 hover:border-gray-500 focus-visible:outline-gray-500 text-gray-400 hover:text-gray-500 px-2.5 py-1.5;
 }
 
 .ais-Feedback-buttonsWrapper {
-    @apply flex space-x-3 items-center;
+  @apply flex space-x-3 items-center;
 }
 
 .ais-Feedback-buttonIcon {
-    @apply h-4 w-4 stroke-2 flex-shrink-0;
+  @apply h-4 w-4 stroke-2 flex-shrink-0;
 }
 
 /* error loading guide */
 .ais-GuideContentError {
-    @apply flex flex-col items-center text-center gap-y-4 max-w-prose mx-auto my-6;
+  @apply flex flex-col items-center text-center gap-y-4 max-w-prose mx-auto my-6;
 }
 
 .ais-GuideContentErrorTitle {
-    @apply text-lg font-semibold;
+  @apply text-lg font-semibold;
 }
 ```
 

--- a/packages/generative-experiences-js/src/hooks/useGuidesHeadlines.ts
+++ b/packages/generative-experiences-js/src/hooks/useGuidesHeadlines.ts
@@ -20,7 +20,7 @@ export function useGuidesHeadlines(props: GuideHeadlinesOptions) {
       object,
       category,
       breadcrumbs,
-      nbHeadlines = 4,
+      maxHeadlines = 4,
       source = 'index',
       searchParams,
       onlyPublished,
@@ -39,7 +39,7 @@ export function useGuidesHeadlines(props: GuideHeadlinesOptions) {
           category,
           object,
           breadcrumbs,
-          nbHeadlines,
+          maxHeadlines,
           searchParams,
           onlyPublished,
         })
@@ -47,7 +47,7 @@ export function useGuidesHeadlines(props: GuideHeadlinesOptions) {
           setError(err as Error);
         });
 
-      if (hits && hits.length === nbHeadlines) {
+      if (hits && hits.length) {
         setStatus('idle');
         setHeadlines(hits);
         return;

--- a/packages/generative-experiences-react/README.md
+++ b/packages/generative-experiences-react/README.md
@@ -78,7 +78,7 @@ function App({ userToken, category }) {
 | Prop name | Type | Default | Description | Notes |
 | --- | --- | --- | --- | --- |
 | `client` | - | N/A | The Algolia Generative Experiences client. | `required` |
-| `category` | `string` | N/A | The category to use for retrieving/generating the headlines. | `required` |
+| `category` | `string \| undefined` | N/A | The category to use for retrieving/generating the headlines. | - |
 | `nbHeadlines` | `number \| undefined` | 4 | The number of headlines to display. | - |
 | `onlyPublished` | `boolean` | `true` | Only return headlines that have had their content generated. | - |
 | `showImmediate` | `boolean` | `false` | Whether to generate/display the headlines on load. | - |
@@ -128,21 +128,21 @@ function App({ currentObjectID, userToken }) {
 }
 ```
 
-| Prop name | Type                | Default                        | Description                                                                     | Notes                                  |
-| --- |---------------------|--------------------------------|---------------------------------------------------------------------------------|----------------------------------------|
-| `client` | -                   | N/A                            | The Algolia Generative Experiences client.                                      | `required`                             |
-| `objectID` | `string`            | N/A                            | The objectID for the guide to be retrieved/generated.                           | `required`                             |
-| `itemComponent` | `ReactNode`         | N/A                            | Component to display items (from an algolia index) listed throughout the guide. | `required`                             |
-| `featuredItemsTitle` | `string`            | Items featured in this article | The title of the realted items carousel found at the end of a guide.            | -                                      |
-| `maxFeaturedItems` | `number`            | 4                              | The number of featured items displayed at the end of a guide.                   | -                                      |
-| `onlyPublished` | `boolean`           | `true`                         | Only display published guides.                                                  | -                                      |
-| `showImmediate` | `boolean`           | `true`                         | Whether to generate/display the content on load.                                | -                                      |
-| `showFeedback` | `boolean`           | `false`                        | Whether to show the feedback buttons.                                           | -                                      |
-| `userToken` | `string`            | N/A                            | The user token needed for computing feedback.                                   | `required` if `showFeedback` is `true` |
-| `getters` | `CommersGetters`    | -                              | The custom gathers that help you fetch images and add links.                    | -                                      |
-| `children` | `ReactNode`         | -                              | The children to render.                                                         | -                                      |
-| `view` | `ViewProps`         | -                              | The view component into which your guide content will be rendered.              | -                                      |
-| `classNames` | `ContentClassNames` | -                              | The class names for the component.                                              | -                                      |
+| Prop name | Type | Default | Description | Notes |
+| --- | --- | --- | --- | --- |
+| `client` | - | N/A | The Algolia Generative Experiences client. | `required` |
+| `objectID` | `string` | N/A | The objectID for the guide to be retrieved/generated. | `required` |
+| `itemComponent` | `ReactNode` | N/A | Component to display items (from an algolia index) listed throughout the guide. | `required` |
+| `featuredItemsTitle` | `string` | Items featured in this article | The title of the realted items carousel found at the end of a guide. | - |
+| `maxFeaturedItems` | `number` | 4 | The number of featured items displayed at the end of a guide. | - |
+| `onlyPublished` | `boolean` | `true` | Only display published guides. | - |
+| `showImmediate` | `boolean` | `true` | Whether to generate/display the content on load. | - |
+| `showFeedback` | `boolean` | `false` | Whether to show the feedback buttons. | - |
+| `userToken` | `string` | N/A | The user token needed for computing feedback. | `required` if `showFeedback` is `true` |
+| `getters` | `CommersGetters` | - | The custom gathers that help you fetch images and add links. | - |
+| `children` | `ReactNode` | - | The children to render. | - |
+| `view` | `ViewProps` | - | The view component into which your guide content will be rendered. | - |
+| `classNames` | `ContentClassNames` | - | The class names for the component. | - |
 
 ### Guides Feedback
 
@@ -254,131 +254,131 @@ To integrate the widgets with Tailwind, include the `@tailwindcss/typography` pl
 
 ```css
 .ais-NoWrap {
-    @apply whitespace-nowrap;
+  @apply whitespace-nowrap;
 }
 
 .ais-ScreenReaderOnly {
-    @apply sr-only;
+  @apply sr-only;
 }
 
 /* display headlines */
 .ais-GuideHeadlinesContent-wrapper {
-    @apply rounded p-4 border border-gray-100 shadow gap-2;
+  @apply rounded p-4 border border-gray-100 shadow gap-2;
 }
 
 .ais-GuideHeadlinesContent-container {
-    @apply flex flex-col items-end;
+  @apply flex flex-col items-end;
 }
 
 .ais-GuideHeadlinesContent-itemsContainer {
-    @apply flex items-center gap-6;
+  @apply flex items-center gap-6;
 }
 
 .ais-GuideHeadlinesContent-readMore {
-    @apply flex text-white py-2 mt-8 border-2 bg-blue-700 rounded-md items-center w-full justify-center;
+  @apply flex text-white py-2 mt-8 border-2 bg-blue-700 rounded-md items-center w-full justify-center;
 }
 
 .ais-GuideHeadlinesContent-item {
-    @apply bg-neutral-100 rounded p-4 space-y-3 flex justify-between min-h-[420px];
+  @apply bg-neutral-100 rounded p-4 space-y-3 flex justify-between min-h-[420px];
 }
 
 .ais-GuideHeadlinesContent-itemContent {
-    @apply mt-5;
+  @apply mt-5;
 }
 
 .ais-GuideHeadlinesContent-itemTitle {
-    @apply text-blue-800 font-semibold line-clamp-2 h-12;
+  @apply text-blue-800 font-semibold line-clamp-2 h-12;
 }
 
 .ais-GuideHeadlinesContent-itemDescription {
-    @apply line-clamp-4 text-base mt-2;
+  @apply line-clamp-4 text-base mt-2;
 }
 
 .ais-GuideHeadlinesContent-itemImage {
-    @apply relative min-h-[120px] max-h-[120px] w-auto overflow-hidden mx-auto mt-4 aspect-square;
+  @apply relative min-h-[120px] max-h-[120px] w-auto overflow-hidden mx-auto mt-4 aspect-square;
 }
 
 /* display content */
 .ais-GuideContent-contentSection {
-    @apply prose max-w-prose mx-auto px-4;
+  @apply prose max-w-prose mx-auto px-4;
 }
 
 .ais-GuideContent {
-    @apply mb-10 w-full;
+  @apply mb-10 w-full;
 }
 
 .ais-GuideContent-heroImage {
-    @apply mx-auto min-h-[200px] max-h-[250px] my-12;
+  @apply mx-auto min-h-[200px] max-h-[250px] my-12;
 }
 
 .ais-GuideContent .ais-Feedback {
-    @apply flex items-end justify-end mx-auto;
+  @apply flex items-end justify-end mx-auto;
 }
 
 .ais-GuideContent-factorsList {
-    @apply flex flex-wrap list-disc gap-x-2 justify-between w-full;
+  @apply flex flex-wrap list-disc gap-x-2 justify-between w-full;
 }
 
 .ais-GuideContent-factorItem {
-    @apply w-[45%];
+  @apply w-[45%];
 }
 
 .ais-GuideContent-relatedItemsSection {
-    @apply prose max-w-none mx-auto px-4;
+  @apply prose max-w-none mx-auto px-4;
 }
 
 .ais-GuideContent-relatedItemsTitle {
-    @apply max-w-prose mx-auto px-4;
+  @apply max-w-prose mx-auto px-4;
 }
 
 .ais-GuideContent-relatedItemsListContainer {
-    @apply max-w-prose mx-auto px-4;
+  @apply max-w-prose mx-auto px-4;
 }
 
 .ais-GuideContent-relatedItemsList {
-    @apply p-2 flex justify-between flex-wrap list-none;
+  @apply p-2 flex justify-between flex-wrap list-none;
 }
 
 /* display feedback */
 .ais-Feedback {
-    @apply text-gray-500 text-base max-w-prose mt-10;
+  @apply text-gray-500 text-base max-w-prose mt-10;
 }
 
 .ais-feedbackContainer {
-    @apply flex items-center gap-4;
+  @apply flex items-center gap-4;
 }
 
 .ais-Feedback-thanksWrapper {
-    @apply flex items-center;
+  @apply flex items-center;
 }
 
 .ais-Feedback-labelWrapper {
-    @apply flex space-x-2 items-center;
+  @apply flex space-x-2 items-center;
 }
 
 .ais-Feedback-labelIcon {
-    @apply h-6 w-6 flex-shrink-0;
+  @apply h-6 w-6 flex-shrink-0;
 }
 
 .ais-Feedback-button {
-    @apply inline-block rounded font-semibold text-center shadow-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 bg-white hover:bg-white border-2 border-gray-400 hover:border-gray-500 focus-visible:outline-gray-500 text-gray-400 hover:text-gray-500 px-2.5 py-1.5;
+  @apply inline-block rounded font-semibold text-center shadow-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 bg-white hover:bg-white border-2 border-gray-400 hover:border-gray-500 focus-visible:outline-gray-500 text-gray-400 hover:text-gray-500 px-2.5 py-1.5;
 }
 
 .ais-Feedback-buttonsWrapper {
-    @apply flex space-x-3 items-center;
+  @apply flex space-x-3 items-center;
 }
 
 .ais-Feedback-buttonIcon {
-    @apply h-4 w-4 stroke-2 flex-shrink-0;
+  @apply h-4 w-4 stroke-2 flex-shrink-0;
 }
 
 /* error loading guide */
 .ais-GuideContentError {
-    @apply flex flex-col items-center text-center gap-y-4 max-w-prose mx-auto my-6;
+  @apply flex flex-col items-center text-center gap-y-4 max-w-prose mx-auto my-6;
 }
 
 .ais-GuideContentErrorTitle {
-    @apply text-lg font-semibold;
+  @apply text-lg font-semibold;
 }
 ```
 

--- a/packages/generative-experiences-react/README.md
+++ b/packages/generative-experiences-react/README.md
@@ -79,7 +79,7 @@ function App({ userToken, category }) {
 | --- | --- | --- | --- | --- |
 | `client` | - | N/A | The Algolia Generative Experiences client. | `required` |
 | `category` | `string \| undefined` | N/A | The category to use for retrieving/generating the headlines. | - |
-| `nbHeadlines` | `number \| undefined` | 4 | The number of headlines to display. | - |
+| `maxHeadlines` | `number \| undefined` | 4 | The maximum number of headlines to display. | Maximum 1,000 |
 | `onlyPublished` | `boolean` | `true` | Only return headlines that have had their content generated. | - |
 | `showImmediate` | `boolean` | `false` | Whether to generate/display the headlines on load. | - |
 | `showFeedback` | `boolean` | `false` | Whether to show the feedback buttons. | - |

--- a/packages/generative-experiences-react/src/__test__/useGuidesHeadlines.test.ts
+++ b/packages/generative-experiences-react/src/__test__/useGuidesHeadlines.test.ts
@@ -23,7 +23,7 @@ describe('useGuidesHeadlines', () => {
           client,
           showImmediate: true,
           category: 'some-category',
-          nbHeadlines: 1,
+          maxHeadlines: 1,
         })
       );
 

--- a/packages/generative-experiences-react/src/useGuidesHeadlines.ts
+++ b/packages/generative-experiences-react/src/useGuidesHeadlines.ts
@@ -22,7 +22,7 @@ export function useGuidesHeadlines({
       object,
       category,
       breadcrumbs,
-      nbHeadlines = 4,
+      maxHeadlines = 4,
       source = 'index',
       searchParams,
       onlyPublished,
@@ -41,7 +41,7 @@ export function useGuidesHeadlines({
           category,
           object,
           breadcrumbs,
-          nbHeadlines,
+          maxHeadlines,
           searchParams,
           onlyPublished,
         })
@@ -49,7 +49,7 @@ export function useGuidesHeadlines({
           setError(err as Error);
         });
 
-      if (hits && hits.length === nbHeadlines) {
+      if (hits && hits.length) {
         setStatus('idle');
         setHeadlines(hits);
         return;


### PR DESCRIPTION
Comparison guides don't require a category to be set. Therefore getting the headlines shouldn't require a category filter.