### PR TITLE
fix: allow api-client to be used in node

### DIFF
--- a/examples/playground-js/src/index.tsx
+++ b/examples/playground-js/src/index.tsx
@@ -28,13 +28,13 @@ guidesHeadlines({
   showImmediate: true,
   onlyPublished: false,
   showFeedback: true,
-  category: 'category',
+  category: 'Original Starter Pokemon',
 });
 
 guidesFeedback({
   container: '#feedback',
   client,
-  objectIDs: ['123'],
+  objectIDs: ['067e80a2-572a-4cf5-ae8c-e35eac450601'],
   userToken: 'test-user',
 });
 
@@ -47,6 +47,6 @@ guideContent<RecordType>({
     return <div>{hit.title}</div>;
   },
   showFeedback: true,
-  objectID: '123',
+  objectID: '067e80a2-572a-4cf5-ae8c-e35eac450601',
   userToken: 'test-user',
 });

--- a/examples/playground-node/package.json
+++ b/examples/playground-node/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "playground-node",
+  "version": "2.1.0",
+  "description": "playground for testing library",
+  "license": "MIT",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algolia/generative-experiences.git"
+  },
+  "bugs": {
+    "url": "https://github.com/algolia/generative-experiences/issues"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "node ./src/index.js",
+    "dev": "node ./src/index.js"
+  },
+  "dependencies": {
+    "@algolia/generative-experiences-api-client": "2.1.0"
+  }
+}

--- a/examples/playground-node/src/index.js
+++ b/examples/playground-node/src/index.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-console */
+import { createClient } from '@algolia/generative-experiences-api-client';
+
+const options = {
+  appId: process.env.VITE_EXAMPLES_APP_ID ?? '',
+  indexName: process.env.VITE_EXAMPLES_INDEX_NAME ?? '',
+  searchOnlyAPIKey: process.env.VITE_EXAMPLES_SEARCH_ONLY_API_KEY ?? '',
+  writeAPIKey: process.env.VITE_EXAMPLES_WRITE_API_KEY ?? '',
+};
+
+const client = createClient(options);
+
+client
+  .getHeadlines({
+    category: 'Original Starter Pokemon',
+    onlyPublished: false,
+  })
+  .then((headlines) => {
+    console.log(
+      'Headlines:',
+      headlines.map((h) => h.title)
+    );
+  })
+  .catch((error) => {
+    console.error('Error fetching headlines:', error);
+  });
+
+client
+  .getContent({
+    objectID: '067e80a2-572a-4cf5-ae8c-e35eac450601',
+    onlyPublished: false,
+  })
+  .then((content) => {
+    console.log('Content:', content.title);
+  })
+  .catch((error) => {
+    console.error('Error fetching content:', error);
+  });

--- a/examples/playground/src/index.tsx
+++ b/examples/playground/src/index.tsx
@@ -66,16 +66,20 @@ function PlaygroundApp() {
         showFeedback
         userToken="aabc"
         client={client}
-        category="cateogry"
+        category="Original Starter Pokemon"
         onlyPublished={false}
         showImmediate
       />
-      <GuidesFeedback client={client} objectIDs={['123']} userToken="abc" />
+      <GuidesFeedback
+        client={client}
+        objectIDs={['067e80a2-572a-4cf5-ae8c-e35eac450601']}
+        userToken="abc"
+      />
       <GuideContent
         client={client}
         showFeedback
         userToken="aabc"
-        objectID="123"
+        objectID="067e80a2-572a-4cf5-ae8c-e35eac450601"
         onlyPublished={false}
         itemComponent={({ hit }) => <ItemComponent hit={hit} />}
       />
@@ -84,7 +88,7 @@ function PlaygroundApp() {
 }
 
 const container = document.getElementById('root');
-const root = createRoot(container!); // createRoot(container!) if you use TypeScript
+const root = createRoot(container!);
 root.render(
   <React.StrictMode>
     <PlaygroundApp />

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "playground:dev": "lerna run dev --scope playground",
     "playground-js:dev": "lerna run dev --scope playground-js",
     "playground-js:build": "lerna run build --scope playground-js",
+    "playground-node:dev": "lerna run dev --scope playground-node",
+    "playground-node:build": "lerna run build --scope playground-node",
     "release": "shipjs prepare",
     "test": "lerna run test --scope @algolia/generative-experiences-* --no-private",
     "test:ci": "lerna run test:ci --scope @algolia/generative-experiences-* --no-private",

--- a/packages/generative-experiences-api-client/package.json
+++ b/packages/generative-experiences-api-client/package.json
@@ -13,8 +13,15 @@
     "url": "https://www.algolia.com"
   },
   "type": "module",
-  "main": "dist/index.umd.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/generative-experiences-api-client/vite.config.ts
+++ b/packages/generative-experiences-api-client/vite.config.ts
@@ -15,20 +15,44 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),
       name: '@algolia/generative-experiences-api-client',
-      fileName: 'index',
+      fileName: (format) => {
+        if (format === 'es') {
+          return 'index.js';
+        }
+        if (format === 'cjs') {
+          return 'index.cjs';
+        }
+        return 'index.umd.js';
+      },
     },
     rollupOptions: {
+      external: [
+        // Mark these as external to avoid bundling them
+        '@algolia/client-search',
+        'algoliasearch',
+        'algoliasearch-helper',
+      ],
       output: [
         {
           format: 'umd',
           dir: path.resolve(__dirname, 'dist/'),
           entryFileNames: 'index.umd.js',
-          name: '@algolia/generative-experiences-api-client',
+          name: 'AlgoliaGenerativeExperiencesApiClient',
+          globals: {
+            '@algolia/client-search': 'AlgoliaClientSearch',
+            algoliasearch: 'algoliasearch',
+            'algoliasearch-helper': 'algoliasearchHelper',
+          },
         },
         {
-          format: 'esm',
+          format: 'es',
           dir: path.resolve(__dirname, 'dist/'),
           entryFileNames: 'index.js',
+        },
+        {
+          format: 'cjs',
+          dir: path.resolve(__dirname, 'dist/'),
+          entryFileNames: 'index.cjs',
         },
       ],
     },


### PR DESCRIPTION
Fix the issue where the API client is throwing import + XHR issues in Node.


### Side quest 

Update playground values to match the guides generated in app `F5TW3UFH5U`